### PR TITLE
Alternate spelling

### DIFF
--- a/app/admin/entry.rb
+++ b/app/admin/entry.rb
@@ -18,7 +18,7 @@ ActiveAdmin.register Entry do
 
   actions :all, except: [:show]
 
-  permit_params :entry_word, :word_type, :translation, :alternate_translations_raw, :display_order, :description,
+  permit_params :entry_word, :word_type, :translation, :alternate_translations_raw, :alternate_spellings_raw, :display_order, :description,
                 :published?, :image, :audio, image_credit_attributes: [:attribution_text, :link], category_ids: []
 
   form(html: { multipart: true }) do |f|

--- a/app/admin/entry.rb
+++ b/app/admin/entry.rb
@@ -18,7 +18,7 @@ ActiveAdmin.register Entry do
 
   actions :all, except: [:show]
 
-  permit_params :entry_word, :word_type, :translation, :alternate_translations_raw, :display_order, :description, 
+  permit_params :entry_word, :word_type, :translation, :alternate_translations_raw, :display_order, :description,
                 :published?, :image, :audio, image_credit_attributes: [:attribution_text, :link], category_ids: []
 
   form(html: { multipart: true }) do |f|
@@ -27,6 +27,7 @@ ActiveAdmin.register Entry do
       f.input :word_type, as: :select, collection: Entry::WORD_TYPES
       f.input :translation
       f.input :alternate_translations_raw, as: :text, label: 'Alternate translations - One per line', placeholder: 'One per line', input_html: {rows: 3}
+      f.input :alternate_spellings_raw, as: :text, label: 'Alternate spellings - One per line', placeholder: 'One per line', input_html: {rows: 3}
       f.input :description
       f.input :display_order, hint: 'optional - if not specified will be sorted alphabetically'
       f.input :published?
@@ -79,7 +80,7 @@ ActiveAdmin.register Entry do
     column :categories do |entry|
       entry.categories.map do |c|
         span c.name, class: 'category'
-      end 
+      end
     end
     actions
   end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -1,7 +1,7 @@
 class Entry < ActiveRecord::Base
-	validates :entry_word, :word_type, :translation, presence: true	
+	validates :entry_word, :word_type, :translation, presence: true
 
-  store :extras, accessors: [ :alternate_translations ]
+  store :extras, accessors: [ :alternate_translations, :alternate_spellings]
 
   has_one :image_credit, dependent: :destroy
   accepts_nested_attributes_for :image_credit
@@ -46,6 +46,15 @@ class Entry < ActiveRecord::Base
 
   def self.alphabetically
     order(entry_word: :asc)
+  end
+
+	def alternate_spellings_raw
+    self.alternate_spellings.join("\n") unless self.alternate_spellings.nil?
+  end
+
+  def alternate_spellings_raw= values
+    self.alternate_spellings = []
+    self.alternate_spellings = values.split("\n")
   end
 
   def alternate_translations_raw

--- a/app/serializers/entry_serializer.rb
+++ b/app/serializers/entry_serializer.rb
@@ -1,11 +1,11 @@
 class EntrySerializer < ActiveModel::Serializer
-  attributes :id, :entry_word, :word_type, :translation, :alternate_translations, :description, :audio, :images, :categories
+  attributes :id, :entry_word, :word_type, :translation, :alternate_translations, :alternate_spellings, :description, :audio, :images, :categories
 
   def audio
   	object.audio.url if object.audio.exists?
   end
 
-  def images 
+  def images
   	{
   		thumbnail: object.image? ? object.image(:thumbnail) : nil,
       normal: object.image? ? object.image(:normal) : nil

--- a/spec/controllers/api/sync_controller_spec.rb
+++ b/spec/controllers/api/sync_controller_spec.rb
@@ -3,10 +3,11 @@ require 'rails_helper'
 RSpec.describe Api::SyncController, :type => :controller do
 	let(:category1) { Category.new id: 37, name: 'Family' }
   let(:category2) { Category.new id: 24, name: 'Body Parts' }
-  let(:entry) { Entry.new id: 3, entry_word: 'Mimi', 
+  let(:entry) { Entry.new id: 3, entry_word: 'Mimi',
                                  word_type: 'noun',
-                                 translation: 'Grandma', 
+                                 translation: 'Grandma',
                                  alternate_translations: ['Granny'],
+																 alternate_spellings: ['Mummy'],
                                  description: 'Mum\'s mum',
                                  categories: [category1, category2] }
 
@@ -48,12 +49,13 @@ RSpec.describe Api::SyncController, :type => :controller do
         expect(first_entry['word_type']).to eq('noun')
         expect(first_entry['translation']).to eq('Grandma')
         expect(first_entry['alternate_translations']).to eq(['Granny'])
+				expect(first_entry['alternate_spellings']).to eq(['Mummy'])
         expect(first_entry['description']).to eq('Mum\'s mum')
         expect(first_entry['audio']).to eq('s3.m4a')
         expect(first_entry['images']['thumbnail']).to eq('thumb.png')
         expect(first_entry['images']['normal']).to eq('normal.png')
         expect(first_entry['categories']).to eq([37,24])
-        
+
       end
     end
 
@@ -181,6 +183,6 @@ RSpec.describe Api::SyncController, :type => :controller do
       expect(parsed_response).to have_key('categories')
       expect(parsed_response).to have_key('entries')
       expect(parsed_response).to have_key('image_credits')
-    end 
+    end
   end
 end


### PR DESCRIPTION
New feature to specify alternate spelling for an entry. For instance, a feminine version of the word.